### PR TITLE
Simplify and improve exercises

### DIFF
--- a/random_workout/lib/data/balance_exercises.dart
+++ b/random_workout/lib/data/balance_exercises.dart
@@ -10,10 +10,11 @@ final List<Exercise> balanceExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.calves,
-      MuscleTarget.core
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
+      MuscleTarget.glutes,
     ],
     jointTargets: [JointTarget.ankle, JointTarget.knee, JointTarget.hip],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Tree Pose',
@@ -24,10 +25,10 @@ final List<Exercise> balanceExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.calves,
-      MuscleTarget.core
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
     ],
     jointTargets: [JointTarget.ankle, JointTarget.knee, JointTarget.hip],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Flamingo Stand',
@@ -39,10 +40,10 @@ final List<Exercise> balanceExercises = [
       MuscleTarget.quadriceps,
       MuscleTarget.hamstrings,
       MuscleTarget.calves,
-      MuscleTarget.core
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
     ],
     jointTargets: [JointTarget.ankle, JointTarget.knee, JointTarget.hip],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Tightrope Walk',
@@ -50,9 +51,12 @@ final List<Exercise> balanceExercises = [
     instructions:
         "1. Find a straight line on the floor or imagine one.\n2. Walk heel-to-toe along the line.\n3. Keep your arms out to the sides for balance.\n4. Take 10-15 steps forward, then backward.",
     category: ExerciseCategory.balance,
-    muscleTargets: [MuscleTarget.calves, MuscleTarget.core],
+    muscleTargets: [
+      MuscleTarget.calves,
+      MuscleTarget.abdominals,
+      MuscleTarget.quadriceps,
+    ],
     jointTargets: [JointTarget.ankle],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Single Leg Deadlift',
@@ -63,11 +67,12 @@ final List<Exercise> balanceExercises = [
     muscleTargets: [
       MuscleTarget.hamstrings,
       MuscleTarget.glutes,
-      MuscleTarget.core,
-      MuscleTarget.back
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
+      MuscleTarget.lats,
+      MuscleTarget.traps,
     ],
     jointTargets: [JointTarget.ankle, JointTarget.knee, JointTarget.hip],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Warrior III Pose',
@@ -76,12 +81,13 @@ final List<Exercise> balanceExercises = [
         "1. Start in a standing position.\n2. Shift your weight onto one leg.\n3. Lean forward, lifting your other leg behind you.\n4. Extend your arms forward.\n5. Hold for 30 seconds, then switch sides.",
     category: ExerciseCategory.balance,
     muscleTargets: [
-      MuscleTarget.core,
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
+      MuscleTarget.quadriceps,
       MuscleTarget.glutes,
       MuscleTarget.hamstrings
     ],
     jointTargets: [JointTarget.ankle, JointTarget.knee, JointTarget.hip],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Standing Leg Swings',
@@ -89,9 +95,13 @@ final List<Exercise> balanceExercises = [
     instructions:
         "1. Stand on one leg.\n2. Swing the other leg forward and back.\n3. Keep your upper body stable.\n4. Do 15 swings, then switch legs.\n5. Repeat with side-to-side swings.",
     category: ExerciseCategory.balance,
-    muscleTargets: [MuscleTarget.core],
+    muscleTargets: [
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
+      MuscleTarget.quadriceps,
+      MuscleTarget.hipFlexors,
+    ],
     jointTargets: [JointTarget.hip, JointTarget.ankle],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Pillow Balance',
@@ -102,10 +112,10 @@ final List<Exercise> balanceExercises = [
     muscleTargets: [
       MuscleTarget.calves,
       MuscleTarget.quadriceps,
-      MuscleTarget.core
+      MuscleTarget.obliques,
+      MuscleTarget.abdominals,
     ],
     jointTargets: [JointTarget.ankle, JointTarget.knee],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Clock Reach',
@@ -118,10 +128,14 @@ final List<Exercise> balanceExercises = [
       MuscleTarget.quadriceps,
       MuscleTarget.hamstrings,
       MuscleTarget.calves,
-      MuscleTarget.core
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
     ],
-    jointTargets: [JointTarget.ankle, JointTarget.knee, JointTarget.hip],
-    focusAreas: [FocusArea.legs, FocusArea.core],
+    jointTargets: [
+      JointTarget.ankle,
+      JointTarget.knee,
+      JointTarget.hip,
+    ],
   ),
   Exercise(
     name: 'Single Leg Balance with Arm Movements',
@@ -130,12 +144,16 @@ final List<Exercise> balanceExercises = [
         "1. Stand on one leg.\n2. Perform arm circles, punches, or reaches while maintaining balance.\n3. Continue for 30 seconds.\n4. Switch legs and repeat.",
     category: ExerciseCategory.balance,
     muscleTargets: [
-      MuscleTarget.core,
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
       MuscleTarget.shoulders,
       MuscleTarget.quadriceps
     ],
-    jointTargets: [JointTarget.ankle, JointTarget.knee, JointTarget.shoulder],
-    focusAreas: [FocusArea.legs, FocusArea.core],
+    jointTargets: [
+      JointTarget.ankle,
+      JointTarget.knee,
+      JointTarget.shoulder,
+    ],
   ),
   Exercise(
     name: 'Heel-to-Toe Balance Walk',
@@ -143,9 +161,12 @@ final List<Exercise> balanceExercises = [
     instructions:
         "1. Stand with your heel touching the toe of your back foot.\n2. Take a step forward, placing your back foot's heel against the front foot's toe.\n3. Continue for 10-15 steps.\n4. Turn around and return to the start.",
     category: ExerciseCategory.balance,
-    muscleTargets: [MuscleTarget.calves, MuscleTarget.core],
+    muscleTargets: [
+      MuscleTarget.calves,
+      MuscleTarget.quadriceps,
+      MuscleTarget.obliques,
+    ],
     jointTargets: [JointTarget.ankle],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Standing Windmill',
@@ -154,12 +175,12 @@ final List<Exercise> balanceExercises = [
         "1. Stand with feet wider than shoulder-width.\n2. Extend arms out to the sides.\n3. Bend to touch your right hand to your left foot.\n4. Return to standing.\n5. Alternate sides for 10 reps each.",
     category: ExerciseCategory.balance,
     muscleTargets: [
-      MuscleTarget.core,
+      MuscleTarget.quadriceps,
+      MuscleTarget.abdominals,
       MuscleTarget.hamstrings,
       MuscleTarget.obliques
     ],
     jointTargets: [JointTarget.hip, JointTarget.spine],
-    focusAreas: [FocusArea.core],
   ),
   Exercise(
     name: 'Single Leg Romanian Deadlift',
@@ -170,11 +191,12 @@ final List<Exercise> balanceExercises = [
     muscleTargets: [
       MuscleTarget.hamstrings,
       MuscleTarget.glutes,
-      MuscleTarget.core,
-      MuscleTarget.back
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
+      MuscleTarget.lats,
+      MuscleTarget.traps,
     ],
     jointTargets: [JointTarget.hip, JointTarget.knee, JointTarget.ankle],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
   Exercise(
     name: 'Tandem Balance',
@@ -185,9 +207,9 @@ final List<Exercise> balanceExercises = [
     muscleTargets: [
       MuscleTarget.calves,
       MuscleTarget.quadriceps,
-      MuscleTarget.core
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
     ],
     jointTargets: [JointTarget.ankle, JointTarget.knee],
-    focusAreas: [FocusArea.legs, FocusArea.core],
   ),
 ];

--- a/random_workout/lib/data/cardio_exercises.dart
+++ b/random_workout/lib/data/cardio_exercises.dart
@@ -10,10 +10,16 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.calves,
-      MuscleTarget.core
+      MuscleTarget.hamstrings,
+      MuscleTarget.abdominals,
+      MuscleTarget.hipFlexors,
+      MuscleTarget.adductors,
     ],
-    jointTargets: [JointTarget.knee, JointTarget.hip],
-    focusAreas: [FocusArea.legs, FocusArea.core],
+    jointTargets: [
+      JointTarget.knee,
+      JointTarget.hip,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Jumping Jacks',
@@ -24,10 +30,15 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.calves,
-      MuscleTarget.shoulders
+      MuscleTarget.shoulders,
+      MuscleTarget.adductors,
+      MuscleTarget.abductors,
     ],
-    jointTargets: [JointTarget.shoulder, JointTarget.hip, JointTarget.ankle],
-    focusAreas: [FocusArea.legs, FocusArea.arms],
+    jointTargets: [
+      JointTarget.shoulder,
+      JointTarget.hip,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Mountain Climbers',
@@ -36,12 +47,19 @@ final List<Exercise> cardioExercises = [
         "1. Start in a high plank position.\n2. Bring right knee towards chest.\n3. Quickly switch, extending right leg back while bringing left knee in.\n4. Alternate legs as if running in place.\n5. Continue for 30-60 seconds.",
     category: ExerciseCategory.cardio,
     muscleTargets: [
-      MuscleTarget.core,
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
       MuscleTarget.quadriceps,
-      MuscleTarget.shoulders
+      MuscleTarget.shoulders,
+      MuscleTarget.hipFlexors,
+      MuscleTarget.adductors,
     ],
-    jointTargets: [JointTarget.shoulder, JointTarget.hip, JointTarget.knee],
-    focusAreas: [FocusArea.core, FocusArea.legs],
+    jointTargets: [
+      JointTarget.shoulder,
+      JointTarget.hip,
+      JointTarget.knee,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Burpees',
@@ -52,11 +70,17 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.chest,
-      MuscleTarget.core,
-      MuscleTarget.shoulders
+      MuscleTarget.abdominals,
+      MuscleTarget.shoulders,
+      MuscleTarget.glutes,
+      MuscleTarget.hipFlexors,
     ],
-    jointTargets: [JointTarget.shoulder, JointTarget.hip, JointTarget.knee],
-    focusAreas: [FocusArea.fullBody],
+    jointTargets: [
+      JointTarget.shoulder,
+      JointTarget.hip,
+      JointTarget.knee,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Jump Rope (Imaginary)',
@@ -68,10 +92,16 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.calves,
       MuscleTarget.quadriceps,
-      MuscleTarget.shoulders
+      MuscleTarget.shoulders,
+      MuscleTarget.abdominals,
+      MuscleTarget.forearms,
+      MuscleTarget.hipFlexors,
     ],
-    jointTargets: [JointTarget.ankle, JointTarget.knee, JointTarget.wrist],
-    focusAreas: [FocusArea.legs, FocusArea.arms],
+    jointTargets: [
+      JointTarget.ankle,
+      JointTarget.knee,
+      JointTarget.wrist,
+    ],
   ),
   Exercise(
     name: 'Squat Jumps',
@@ -82,10 +112,16 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.glutes,
-      MuscleTarget.calves
+      MuscleTarget.calves,
+      MuscleTarget.hamstrings,
+      MuscleTarget.hipFlexors,
+      MuscleTarget.adductors,
     ],
-    jointTargets: [JointTarget.knee, JointTarget.hip, JointTarget.ankle],
-    focusAreas: [FocusArea.legs],
+    jointTargets: [
+      JointTarget.knee,
+      JointTarget.hip,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Lateral Shuffles',
@@ -96,10 +132,16 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.glutes,
-      MuscleTarget.calves
+      MuscleTarget.calves,
+      MuscleTarget.abdominals,
+      MuscleTarget.abductors,
+      MuscleTarget.adductors,
     ],
-    jointTargets: [JointTarget.knee, JointTarget.hip, JointTarget.ankle],
-    focusAreas: [FocusArea.legs],
+    jointTargets: [
+      JointTarget.knee,
+      JointTarget.hip,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Punch and Kick',
@@ -110,11 +152,20 @@ final List<Exercise> cardioExercises = [
     category: ExerciseCategory.cardio,
     muscleTargets: [
       MuscleTarget.shoulders,
-      MuscleTarget.core,
-      MuscleTarget.quadriceps
+      MuscleTarget.abdominals,
+      MuscleTarget.obliques,
+      MuscleTarget.quadriceps,
+      MuscleTarget.glutes,
+      MuscleTarget.hipFlexors,
+      MuscleTarget.calves,
+      MuscleTarget.abductors,
     ],
-    jointTargets: [JointTarget.shoulder, JointTarget.hip, JointTarget.knee],
-    focusAreas: [FocusArea.fullBody],
+    jointTargets: [
+      JointTarget.shoulder,
+      JointTarget.hip,
+      JointTarget.knee,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Speed Skaters',
@@ -126,10 +177,16 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.glutes,
-      MuscleTarget.calves
+      MuscleTarget.calves,
+      MuscleTarget.abdominals,
+      MuscleTarget.adductors,
+      MuscleTarget.abductors,
     ],
-    jointTargets: [JointTarget.knee, JointTarget.hip, JointTarget.ankle],
-    focusAreas: [FocusArea.legs],
+    jointTargets: [
+      JointTarget.knee,
+      JointTarget.hip,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Plank Jacks',
@@ -138,12 +195,19 @@ final List<Exercise> cardioExercises = [
         "1. Start in a high plank position.\n2. Jump both feet out wide.\n3. Immediately jump feet back together.\n4. Keep core engaged throughout.\n5. Continue for 30-60 seconds.",
     category: ExerciseCategory.cardio,
     muscleTargets: [
-      MuscleTarget.core,
+      MuscleTarget.abdominals,
       MuscleTarget.shoulders,
-      MuscleTarget.quadriceps
+      MuscleTarget.quadriceps,
+      MuscleTarget.calves,
+      MuscleTarget.glutes,
+      MuscleTarget.adductors,
+      MuscleTarget.abductors,
     ],
-    jointTargets: [JointTarget.shoulder, JointTarget.hip],
-    focusAreas: [FocusArea.core, FocusArea.legs],
+    jointTargets: [
+      JointTarget.shoulder,
+      JointTarget.hip,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Butt Kicks',
@@ -151,9 +215,16 @@ final List<Exercise> cardioExercises = [
     instructions:
         "1. Stand in place with feet hip-width apart.\n2. Run in place, kicking your heels up towards your buttocks.\n3. Keep your thighs relatively stationary.\n4. Swing your arms as if running.\n5. Continue for 30-60 seconds.",
     category: ExerciseCategory.cardio,
-    muscleTargets: [MuscleTarget.hamstrings, MuscleTarget.calves],
-    jointTargets: [JointTarget.knee, JointTarget.hip],
-    focusAreas: [FocusArea.legs],
+    muscleTargets: [
+      MuscleTarget.hamstrings,
+      MuscleTarget.calves,
+      MuscleTarget.quadriceps,
+      MuscleTarget.hipFlexors,
+    ],
+    jointTargets: [
+      JointTarget.knee,
+      JointTarget.hip,
+    ],
   ),
   Exercise(
     name: 'Star Jumps',
@@ -164,10 +235,18 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.glutes,
-      MuscleTarget.shoulders
+      MuscleTarget.shoulders,
+      MuscleTarget.calves,
+      MuscleTarget.abdominals,
+      MuscleTarget.adductors,
+      MuscleTarget.abductors,
     ],
-    jointTargets: [JointTarget.knee, JointTarget.hip, JointTarget.shoulder],
-    focusAreas: [FocusArea.fullBody],
+    jointTargets: [
+      JointTarget.knee,
+      JointTarget.hip,
+      JointTarget.shoulder,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Skater Hops',
@@ -179,10 +258,16 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.glutes,
-      MuscleTarget.calves
+      MuscleTarget.calves,
+      MuscleTarget.abdominals,
+      MuscleTarget.adductors,
+      MuscleTarget.abductors,
     ],
-    jointTargets: [JointTarget.knee, JointTarget.hip, JointTarget.ankle],
-    focusAreas: [FocusArea.legs],
+    jointTargets: [
+      JointTarget.knee,
+      JointTarget.hip,
+      JointTarget.ankle,
+    ],
   ),
   Exercise(
     name: 'Invisible Jump Rope Sprints',
@@ -193,10 +278,17 @@ final List<Exercise> cardioExercises = [
     muscleTargets: [
       MuscleTarget.calves,
       MuscleTarget.quadriceps,
-      MuscleTarget.hamstrings
+      MuscleTarget.hamstrings,
+      MuscleTarget.abdominals,
+      MuscleTarget.hipFlexors,
+      MuscleTarget.adductors,
     ],
-    jointTargets: [JointTarget.knee, JointTarget.hip, JointTarget.ankle],
-    focusAreas: [FocusArea.legs],
+    jointTargets: [
+      JointTarget.knee,
+      JointTarget.hip,
+      JointTarget.ankle,
+      JointTarget.shoulder,
+    ],
   ),
   Exercise(
     name: 'Half Burpees',
@@ -207,10 +299,119 @@ final List<Exercise> cardioExercises = [
     category: ExerciseCategory.cardio,
     muscleTargets: [
       MuscleTarget.quadriceps,
-      MuscleTarget.core,
+      MuscleTarget.abdominals,
+      MuscleTarget.shoulders,
+      MuscleTarget.glutes,
+      MuscleTarget.hipFlexors,
+    ],
+    jointTargets: [
+      JointTarget.knee,
+      JointTarget.hip,
+      JointTarget.shoulder,
+      JointTarget.ankle,
+    ],
+  ),
+  Exercise(
+    name: 'Woodchoppers',
+    description:
+        'Rotational exercise that targets obliques and improves core stability',
+    instructions:
+        "1. Stand with feet shoulder-width apart.\n2. Hold a weight or medicine ball with both hands.\n3. Rotate your torso and arms from high on one side to low on the opposite side.\n4. Return to starting position.\n5. Perform 10-15 reps on each side.",
+    category: ExerciseCategory.cardio,
+    muscleTargets: [
+      MuscleTarget.obliques,
+      MuscleTarget.abdominals,
       MuscleTarget.shoulders
     ],
-    jointTargets: [JointTarget.knee, JointTarget.hip, JointTarget.shoulder],
-    focusAreas: [FocusArea.fullBody],
+    jointTargets: [JointTarget.spine, JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Standing Cross-Body Crunch',
+    description: 'Engages obliques and improves coordination',
+    instructions:
+        "1. Stand with feet shoulder-width apart.\n2. Lift your right knee and left elbow, bringing them together in front of your body.\n3. Return to starting position.\n4. Repeat on the other side.\n5. Alternate sides for 30-60 seconds.",
+    category: ExerciseCategory.cardio,
+    muscleTargets: [
+      MuscleTarget.obliques,
+      MuscleTarget.hipFlexors,
+      MuscleTarget.abdominals
+    ],
+    jointTargets: [JointTarget.hip, JointTarget.knee, JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Lateral Lunges with Arm Raise',
+    description: 'Targets abductors, hip flexors, and shoulders',
+    instructions:
+        "1. Stand with feet together.\n2. Take a large step to the right, lowering into a side lunge.\n3. Simultaneously raise both arms overhead.\n4. Push off right foot to return to starting position.\n5. Repeat on the left side.\n6. Alternate sides for 30-60 seconds.",
+    category: ExerciseCategory.cardio,
+    muscleTargets: [
+      MuscleTarget.abductors,
+      MuscleTarget.hipFlexors,
+      MuscleTarget.shoulders,
+      MuscleTarget.quadriceps
+    ],
+    jointTargets: [JointTarget.hip, JointTarget.knee, JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Plank to Downward Dog Tap',
+    description: 'Engages core, shoulders, and improves flexibility',
+    instructions:
+        "1. Start in a high plank position.\n2. Push hips up and back into downward dog position.\n3. Lift right hand and tap left ankle.\n4. Return to downward dog.\n5. Repeat with left hand tapping right ankle.\n6. Return to plank position.\n7. Continue for 30-60 seconds.",
+    category: ExerciseCategory.cardio,
+    muscleTargets: [
+      MuscleTarget.abdominals,
+      MuscleTarget.shoulders,
+      MuscleTarget.triceps,
+      MuscleTarget.hipFlexors
+    ],
+    jointTargets: [JointTarget.shoulder, JointTarget.wrist, JointTarget.hip],
+  ),
+  Exercise(
+    name: 'Sumo Squat with Upright Row',
+    description:
+        'Combines lower body and upper body movements for a full-body cardio exercise',
+    instructions:
+        "1. Stand with feet wider than shoulder-width, toes pointed out.\n2. Hold a weight or resistance band in front of thighs.\n3. Lower into a sumo squat.\n4. As you stand, perform an upright row by lifting the weight to chin level, elbows out.\n5. Lower the weight as you return to squat position.\n6. Repeat for 30-60 seconds.",
+    category: ExerciseCategory.cardio,
+    muscleTargets: [
+      MuscleTarget.quadriceps,
+      MuscleTarget.adductors,
+      MuscleTarget.shoulders,
+      MuscleTarget.traps
+    ],
+    jointTargets: [JointTarget.hip, JointTarget.knee, JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Standing Oblique Crunch',
+    description: 'Targets obliques while improving balance',
+    instructions:
+        "1. Stand with feet shoulder-width apart.\n2. Place hands behind head, elbows out.\n3. Lift right knee towards right elbow, crunching sideways.\n4. Lower leg and repeat on the left side.\n5. Alternate sides for 30-60 seconds.",
+    category: ExerciseCategory.cardio,
+    muscleTargets: [
+      MuscleTarget.obliques,
+      MuscleTarget.hipFlexors,
+      MuscleTarget.abdominals
+    ],
+    jointTargets: [JointTarget.hip, JointTarget.knee, JointTarget.spine],
+  ),
+  Exercise(
+    name: 'Inchworm Walk with Push-Up',
+    description: 'Full-body exercise that targets upper body and core',
+    instructions:
+        "1. Stand with feet hip-width apart.\n2. Bend at the waist and walk hands out to a high plank position.\n3. Perform a push-up.\n4. Walk feet towards hands, keeping legs straight.\n5. Stand up and repeat for 30-60 seconds.",
+    category: ExerciseCategory.cardio,
+    muscleTargets: [
+      MuscleTarget.chest,
+      MuscleTarget.triceps,
+      MuscleTarget.shoulders,
+      MuscleTarget.abdominals,
+      MuscleTarget.hamstrings
+    ],
+    jointTargets: [
+      JointTarget.shoulder,
+      JointTarget.elbow,
+      JointTarget.wrist,
+      JointTarget.hip
+    ],
   ),
 ];

--- a/random_workout/lib/data/mobility_exercises.dart
+++ b/random_workout/lib/data/mobility_exercises.dart
@@ -7,7 +7,6 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Stand with feet shoulder-width apart.\n2. Extend arms out to the sides.\n3. Make small circles with your arms, gradually increasing the size.\n4. Reverse direction after 30 seconds.\n5. Repeat for desired duration.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.shoulders, FocusArea.upperBody],
     muscleTargets: [MuscleTarget.shoulders],
     jointTargets: [JointTarget.shoulder],
   ),
@@ -17,8 +16,7 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Stand with feet shoulder-width apart.\n2. Place hands on hips.\n3. Rotate hips in a circular motion.\n4. Reverse direction after 30 seconds.\n5. Repeat for desired duration.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.hips, FocusArea.lowerBack],
-    muscleTargets: [MuscleTarget.hips],
+    muscleTargets: [MuscleTarget.glutes, MuscleTarget.hipFlexors],
     jointTargets: [JointTarget.hip],
   ),
   Exercise(
@@ -27,7 +25,6 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Sit on the floor with one leg extended.\n2. Rotate your ankle in a circular motion.\n3. Reverse direction after 30 seconds.\n4. Repeat with the other ankle.\n5. Perform for desired duration.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.ankles],
     muscleTargets: [MuscleTarget.calves],
     jointTargets: [JointTarget.ankle],
   ),
@@ -37,9 +34,8 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Stand with feet shoulder-width apart.\n2. Slowly lower your ear to your shoulder.\n3. Roll your head forward and then to the other shoulder.\n4. Repeat in the opposite direction.\n5. Perform for desired duration.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.neck],
-    muscleTargets: [MuscleTarget.neck],
-    jointTargets: [JointTarget.cervicalSpine],
+    muscleTargets: [MuscleTarget.traps],
+    jointTargets: [JointTarget.neck],
   ),
   Exercise(
     name: 'Wrist Flexion and Extension',
@@ -47,7 +43,6 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Extend one arm in front of you at shoulder height.\n2. Point fingers down and use the other hand to apply gentle pressure.\n3. Hold for 15-30 seconds.\n4. Point fingers up and apply gentle pressure.\n5. Hold for 15-30 seconds.\n6. Repeat with the other wrist.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.wrists],
     muscleTargets: [MuscleTarget.forearms],
     jointTargets: [JointTarget.wrist],
   ),
@@ -57,8 +52,7 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Stand with feet shoulder-width apart.\n2. Lift shoulders up towards your ears.\n3. Hold for 2-3 seconds.\n4. Relax and lower shoulders back down.\n5. Repeat for desired reps.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.shoulders],
-    muscleTargets: [MuscleTarget.upperBack],
+    muscleTargets: [MuscleTarget.traps],
     jointTargets: [JointTarget.shoulder],
   ),
   Exercise(
@@ -67,9 +61,8 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Stand with feet shoulder-width apart.\n2. Extend arms out to the sides.\n3. Twist your torso to one side, keeping hips facing forward.\n4. Return to center and twist to the other side.\n5. Repeat for desired reps.",
     category: ExerciseCategory.mobility,
-    muscleTargets: [MuscleTarget.abdominals],
+    muscleTargets: [MuscleTarget.abdominals, MuscleTarget.obliques],
     jointTargets: [JointTarget.spine],
-    focusAreas: [FocusArea.core],
   ),
   Exercise(
     name: 'Cat-Cow',
@@ -77,7 +70,6 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Start on hands and knees in a tabletop position.\n2. Inhale, drop your belly, and lift your gaze (Cow).\n3. Exhale, round your spine, and tuck your chin (Cat).\n4. Repeat for 10-15 cycles.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.core],
     muscleTargets: [MuscleTarget.abdominals],
     jointTargets: [JointTarget.spine],
   ),
@@ -87,9 +79,8 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Start on hands and knees.\n2. Slide one arm under your body, reaching to the opposite side.\n3. Rest your shoulder and cheek on the ground.\n4. Hold for 15-30 seconds, then switch sides.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.upperBack],
-    muscleTargets: [MuscleTarget.upperBack],
-    jointTargets: [JointTarget.thoracicSpine],
+    muscleTargets: [MuscleTarget.shoulders],
+    jointTargets: [JointTarget.spine, JointTarget.shoulder],
   ),
   Exercise(
     name: 'Leg Swings',
@@ -97,8 +88,11 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Stand next to a wall for support.\n2. Swing one leg forward and back.\n3. Do 10 swings, then swing the same leg side to side 10 times.\n4. Switch legs and repeat.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.hips],
-    muscleTargets: [MuscleTarget.hips],
+    muscleTargets: [
+      MuscleTarget.hipFlexors,
+      MuscleTarget.abductors,
+      MuscleTarget.adductors
+    ],
     jointTargets: [JointTarget.hip],
   ),
   Exercise(
@@ -107,7 +101,6 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Hold a stick or resistance band with a wide grip.\n2. Keeping arms straight, bring the stick from in front of your body to behind it.\n3. Return to the starting position.\n4. Repeat for 10-15 reps.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.shoulders],
     muscleTargets: [MuscleTarget.shoulders],
     jointTargets: [JointTarget.shoulder],
   ),
@@ -117,9 +110,12 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Start in a lunge position.\n2. Place the hand on the same side as your front leg on the ground.\n3. Twist your upper body and reach your other hand to the sky.\n4. Hold for a few seconds, then return to the lunge.\n5. Repeat 5 times, then switch sides.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.hips, FocusArea.thighs],
-    muscleTargets: [MuscleTarget.hips, MuscleTarget.quadriceps],
-    jointTargets: [JointTarget.hip, JointTarget.knee],
+    muscleTargets: [
+      MuscleTarget.hipFlexors,
+      MuscleTarget.quadriceps,
+      MuscleTarget.hamstrings
+    ],
+    jointTargets: [JointTarget.hip, JointTarget.knee, JointTarget.spine],
   ),
   Exercise(
     name: 'Thoracic Bridge',
@@ -127,9 +123,8 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Lie on your back with knees bent and feet flat on the floor.\n2. Place your hands on either side of your head, elbows pointing up.\n3. Lift your hips and upper back off the ground, supporting yourself on your feet and hands.\n4. Hold for 15-30 seconds, then lower down.\n5. Repeat 3-5 times.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.upperBack],
-    muscleTargets: [MuscleTarget.upperBack],
-    jointTargets: [JointTarget.thoracicSpine],
+    muscleTargets: [MuscleTarget.shoulders, MuscleTarget.glutes],
+    jointTargets: [JointTarget.spine, JointTarget.shoulder],
   ),
   Exercise(
     name: 'Squat to Stand',
@@ -137,9 +132,12 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Stand with feet hip-width apart.\n2. Bend down and grasp your toes.\n3. Keeping hands on toes, straighten your legs as much as possible.\n4. Bend knees and lower into a squat, keeping your back straight and chest up.\n5. Stand up and repeat for 10 reps.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.hips, FocusArea.ankles],
-    muscleTargets: [MuscleTarget.hips],
-    jointTargets: [JointTarget.hip, JointTarget.ankle],
+    muscleTargets: [
+      MuscleTarget.hamstrings,
+      MuscleTarget.quadriceps,
+      MuscleTarget.glutes
+    ],
+    jointTargets: [JointTarget.hip, JointTarget.ankle, JointTarget.knee],
   ),
   Exercise(
     name: 'Scorpion',
@@ -147,9 +145,8 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Lie face down with arms out to the sides.\n2. Lift one leg and reach it across your body towards the opposite hand.\n3. Return to starting position and repeat with the other leg.\n4. Do 10 reps on each side.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.lowerBack],
-    muscleTargets: [MuscleTarget.lowerBack],
-    jointTargets: [JointTarget.lumbarSpine],
+    muscleTargets: [MuscleTarget.hipFlexors, MuscleTarget.obliques],
+    jointTargets: [JointTarget.spine, JointTarget.hip],
   ),
   Exercise(
     name: 'Wall Slides',
@@ -157,7 +154,6 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Stand with your back against a wall, feet shoulder-width apart.\n2. Press your lower back, upper back, and head against the wall.\n3. Raise your arms up the wall in a 'Y' position, then slide them down to your sides.\n4. Repeat for 10-15 reps.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.shoulders],
     muscleTargets: [MuscleTarget.shoulders],
     jointTargets: [JointTarget.shoulder],
   ),
@@ -167,9 +163,12 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Stand with feet wide apart.\n2. Shift weight to one leg and squat down on that side.\n3. Keep the other leg straight.\n4. Return to center and repeat on the other side.\n5. Do 10 reps on each side.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.hips, FocusArea.ankles],
-    muscleTargets: [MuscleTarget.hips],
-    jointTargets: [JointTarget.hip, JointTarget.knee],
+    muscleTargets: [
+      MuscleTarget.adductors,
+      MuscleTarget.abductors,
+      MuscleTarget.quadriceps
+    ],
+    jointTargets: [JointTarget.hip, JointTarget.knee, JointTarget.ankle],
   ),
   Exercise(
     name: 'Bird Dog',
@@ -177,9 +176,8 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Start on hands and knees.\n2. Extend your right arm forward and left leg back.\n3. Hold for a few seconds, then return to starting position.\n4. Repeat with left arm and right leg.\n5. Do 10 reps on each side.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.core],
-    muscleTargets: [MuscleTarget.abdominals],
-    jointTargets: [JointTarget.spine],
+    muscleTargets: [MuscleTarget.abdominals, MuscleTarget.glutes],
+    jointTargets: [JointTarget.spine, JointTarget.shoulder, JointTarget.hip],
   ),
   Exercise(
     name: 'Prone Scorpion',
@@ -187,9 +185,8 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Lie face down with arms out to the sides.\n2. Bend one knee and reach it across your body towards the opposite hand.\n3. Return to starting position and repeat with the other leg.\n4. Do 10 reps on each side.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.upperBack],
-    muscleTargets: [MuscleTarget.upperBack],
-    jointTargets: [JointTarget.thoracicSpine],
+    muscleTargets: [MuscleTarget.hipFlexors, MuscleTarget.obliques],
+    jointTargets: [JointTarget.spine, JointTarget.hip],
   ),
   Exercise(
     name: 'Downward Dog to Cobra Flow',
@@ -198,8 +195,88 @@ final List<Exercise> mobilityExercises = [
     instructions:
         "1. Start in a downward dog position.\n2. Lower to the ground into a cobra pose, lifting your chest.\n3. Push back up to downward dog.\n4. Repeat this flow for 10 cycles.",
     category: ExerciseCategory.mobility,
-    focusAreas: [FocusArea.core, FocusArea.upperBack],
-    muscleTargets: [MuscleTarget.abdominals, MuscleTarget.upperBack],
-    jointTargets: [JointTarget.spine, JointTarget.shoulder],
+    muscleTargets: [
+      MuscleTarget.shoulders,
+      MuscleTarget.hamstrings,
+      MuscleTarget.calves
+    ],
+    jointTargets: [
+      JointTarget.spine,
+      JointTarget.shoulder,
+      JointTarget.wrist,
+      JointTarget.ankle
+    ],
+  ),
+  Exercise(
+    name: 'Elbow Circles',
+    description: 'Improves elbow joint mobility and forearm flexibility',
+    instructions:
+        "1. Stand with arms at your sides.\n2. Bend your elbows to 90 degrees.\n3. Make small circles with your forearms.\n4. Perform 10 circles in each direction.\n5. Repeat with larger circles.",
+    category: ExerciseCategory.mobility,
+    muscleTargets: [MuscleTarget.forearms],
+    jointTargets: [JointTarget.elbow],
+  ),
+  Exercise(
+    name: 'Wrist Flexor Stretch',
+    description: 'Enhances wrist flexibility and forearm mobility',
+    instructions:
+        "1. Extend one arm in front of you, palm facing down.\n2. Use your other hand to gently pull the fingers back towards your body.\n3. Hold for 15-30 seconds.\n4. Repeat with the other hand.",
+    category: ExerciseCategory.mobility,
+    muscleTargets: [MuscleTarget.forearms],
+    jointTargets: [JointTarget.wrist],
+  ),
+  Exercise(
+    name: 'Neck Clock',
+    description: 'Improves neck mobility and reduces tension',
+    instructions:
+        "1. Imagine your head is the center of a clock.\n2. Slowly tilt your head to each number on the clock.\n3. Hold for 2-3 seconds at each position.\n4. Complete one full rotation clockwise, then counterclockwise.",
+    category: ExerciseCategory.mobility,
+    muscleTargets: [MuscleTarget.traps],
+    jointTargets: [JointTarget.neck],
+  ),
+  Exercise(
+    name: 'Elbow-to-Knee Touch',
+    description: 'Enhances elbow, shoulder, and spine mobility',
+    instructions:
+        "1. Stand with feet shoulder-width apart.\n2. Lift your right elbow up and across your body.\n3. Simultaneously raise your left knee to meet your right elbow.\n4. Return to starting position and alternate sides.\n5. Perform 10 reps on each side.",
+    category: ExerciseCategory.mobility,
+    muscleTargets: [MuscleTarget.obliques],
+    jointTargets: [JointTarget.elbow, JointTarget.shoulder, JointTarget.spine],
+  ),
+  Exercise(
+    name: 'Wrist Rotations',
+    description: 'Improves wrist mobility and forearm flexibility',
+    instructions:
+        "1. Extend both arms in front of you.\n2. Make fists with your hands.\n3. Rotate your fists in circles, keeping your arms still.\n4. Perform 10 rotations in each direction.",
+    category: ExerciseCategory.mobility,
+    muscleTargets: [MuscleTarget.forearms],
+    jointTargets: [JointTarget.wrist],
+  ),
+  Exercise(
+    name: 'Elbow Crawl',
+    description: 'Enhances elbow and shoulder mobility',
+    instructions:
+        "1. Start in a plank position.\n2. Keeping your core tight, slowly lower onto your elbows.\n3. Reverse the movement to return to the plank position.\n4. Perform 10 repetitions.",
+    category: ExerciseCategory.mobility,
+    muscleTargets: [MuscleTarget.shoulders, MuscleTarget.triceps],
+    jointTargets: [JointTarget.elbow, JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Hand Walks',
+    description: 'Improves wrist, elbow, and shoulder mobility',
+    instructions:
+        "1. Start in a standing position, feet shoulder-width apart.\n2. Bend forward and place your hands on the ground in front of you.\n3. Walk your hands forward until you're in a plank position.\n4. Walk your feet towards your hands.\n5. Repeat for 5-10 cycles.",
+    category: ExerciseCategory.mobility,
+    muscleTargets: [MuscleTarget.shoulders, MuscleTarget.hamstrings],
+    jointTargets: [JointTarget.wrist, JointTarget.elbow, JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Neck and Shoulder Release',
+    description: 'Relieves tension in the neck and improves shoulder mobility',
+    instructions:
+        "1. Sit or stand with good posture.\n2. Gently tilt your head to one side, bringing your ear towards your shoulder.\n3. Place the hand of the same side on top of your head, applying gentle pressure.\n4. Hold for 15-30 seconds, then slowly roll your chin down to your chest.\n5. Repeat on the other side.",
+    category: ExerciseCategory.mobility,
+    muscleTargets: [MuscleTarget.traps, MuscleTarget.shoulders],
+    jointTargets: [JointTarget.neck, JointTarget.shoulder],
   ),
 ];

--- a/random_workout/lib/data/strength_exercises.dart
+++ b/random_workout/lib/data/strength_exercises.dart
@@ -1,5 +1,7 @@
 import '../models/exercise.dart';
 
+import '../models/exercise.dart';
+
 final List<Exercise> strengthExercises = [
   Exercise(
     name: 'Push-ups',
@@ -8,7 +10,6 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Start in a plank position with hands shoulder-width apart.\n2. Lower your body until your chest nearly touches the floor.\n3. Push your body back up to the starting position.\n4. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.upperBody],
     muscleTargets: [
       MuscleTarget.chest,
       MuscleTarget.shoulders,
@@ -23,7 +24,6 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Stand with feet shoulder-width apart.\n2. Lower your body as if sitting back into a chair.\n3. Keep your chest up and knees over (not past) your toes.\n4. Lower until thighs are parallel to the ground.\n5. Push through your heels to return to standing.\n6. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.lowerBody],
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.hamstrings,
@@ -38,7 +38,6 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Stand with feet hip-width apart.\n2. Step forward with one leg and lower your hips.\n3. Both knees should bend at about 90-degree angles.\n4. Push back to the starting position.\n5. Repeat, alternating legs, for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.lowerBody],
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.hamstrings,
@@ -52,8 +51,7 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Start in a push-up position with forearms on the ground.\n2. Keep your body in a straight line from head to heels.\n3. Hold this position for the desired amount of time.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.core],
-    muscleTargets: [MuscleTarget.core],
+    muscleTargets: [MuscleTarget.abdominals, MuscleTarget.obliques],
     jointTargets: [JointTarget.spine],
   ),
   Exercise(
@@ -62,11 +60,10 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Start in a standing position.\n2. Drop into a squat position with your hands on the ground.\n3. Kick your feet back, landing in a plank position.\n4. Perform a push-up.\n5. Immediately return your feet to the squat position.\n6. Jump up from the squat position.\n7. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.fullBody],
     muscleTargets: [
       MuscleTarget.quadriceps,
       MuscleTarget.chest,
-      MuscleTarget.core,
+      MuscleTarget.abdominals,
       MuscleTarget.shoulders,
     ],
     jointTargets: [JointTarget.shoulder, JointTarget.hip, JointTarget.knee],
@@ -78,11 +75,11 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Start in a plank position.\n2. Bring one knee towards your chest.\n3. Quickly switch and bring the other knee in.\n4. Continue alternating legs in a running motion.\n5. Maintain for desired duration or reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.core],
     muscleTargets: [
-      MuscleTarget.core,
+      MuscleTarget.abdominals,
       MuscleTarget.quadriceps,
       MuscleTarget.shoulders,
+      MuscleTarget.hipFlexors,
     ],
     jointTargets: [JointTarget.shoulder, JointTarget.hip, JointTarget.knee],
   ),
@@ -92,7 +89,6 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Use parallel bars or the edge of a sturdy chair or bench.\n2. Support your body with arms straight.\n3. Lower your body by bending your elbows.\n4. Push back up to the starting position.\n5. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.upperBody],
     muscleTargets: [
       MuscleTarget.triceps,
       MuscleTarget.chest,
@@ -106,57 +102,8 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Hang from a bar with hands shoulder-width apart.\n2. Pull your body up until your chin clears the bar.\n3. Lower your body back to the starting position.\n4. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.upperBody],
-    muscleTargets: [MuscleTarget.back, MuscleTarget.biceps],
+    muscleTargets: [MuscleTarget.lats, MuscleTarget.biceps],
     jointTargets: [JointTarget.shoulder, JointTarget.elbow],
-  ),
-  Exercise(
-    name: 'Chin-ups',
-    description: 'Variation of pull-ups with greater bicep engagement',
-    instructions:
-        "1. Hang from a bar with hands shoulder-width apart, palms facing you.\n2. Pull your body up until your chin clears the bar.\n3. Lower your body back to the starting position.\n4. Repeat for desired reps.",
-    category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.upperBody],
-    muscleTargets: [MuscleTarget.back, MuscleTarget.biceps],
-    jointTargets: [JointTarget.shoulder, JointTarget.elbow],
-  ),
-  Exercise(
-    name: 'Diamond Push-ups',
-    description: 'Push-up variation with greater focus on triceps',
-    instructions:
-        "1. Start in a push-up position with hands close together under your chest.\n2. Lower your body until your chest nearly touches your hands.\n3. Push your body back up to the starting position.\n4. Repeat for desired reps.",
-    category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.upperBody],
-    muscleTargets: [
-      MuscleTarget.triceps,
-      MuscleTarget.chest,
-      MuscleTarget.shoulders,
-    ],
-    jointTargets: [JointTarget.shoulder, JointTarget.elbow],
-  ),
-  Exercise(
-    name: 'Pike Push-ups',
-    description: 'Shoulder-focused push-up variation',
-    instructions:
-        "1. Start in a push-up position with hips high in the air.\n2. Lower the top of your head towards the ground.\n3. Push your body back up to the starting position.\n4. Repeat for desired reps.",
-    category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.upperBody],
-    muscleTargets: [MuscleTarget.shoulders, MuscleTarget.triceps],
-    jointTargets: [JointTarget.shoulder, JointTarget.elbow],
-  ),
-  Exercise(
-    name: 'Bulgarian Split Squats',
-    description: 'Unilateral leg exercise for balance and strength',
-    instructions:
-        "1. Stand a few feet in front of a bench or elevated surface.\n2. Extend one leg behind you and place the top of your foot on the bench.\n3. Lower your body until your front thigh is parallel to the ground.\n4. Push through your front heel to return to standing.\n5. Repeat for desired reps, then switch legs.",
-    category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.lowerBody],
-    muscleTargets: [
-      MuscleTarget.quadriceps,
-      MuscleTarget.hamstrings,
-      MuscleTarget.glutes,
-    ],
-    jointTargets: [JointTarget.knee, JointTarget.hip],
   ),
   Exercise(
     name: 'Glute Bridge',
@@ -164,7 +111,6 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Lie on your back with knees bent and feet flat on the ground.\n2. Push through your heels to lift your hips towards the ceiling.\n3. Squeeze your glutes at the top of the movement.\n4. Lower your hips back to the starting position.\n5. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.lowerBody],
     muscleTargets: [MuscleTarget.glutes, MuscleTarget.hamstrings],
     jointTargets: [JointTarget.hip],
   ),
@@ -174,8 +120,7 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Sit on the ground with knees bent and feet lifted off the floor.\n2. Lean back slightly and clasp your hands together.\n3. Twist your torso to one side, then the other.\n4. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.core],
-    muscleTargets: [MuscleTarget.core],
+    muscleTargets: [MuscleTarget.obliques, MuscleTarget.abdominals],
     jointTargets: [JointTarget.spine],
   ),
   Exercise(
@@ -184,8 +129,7 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Lie face down with arms extended in front of you.\n2. Lift your arms, chest, and legs off the ground.\n3. Hold this position for a few seconds.\n4. Lower back to the starting position.\n5. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.lowerBack],
-    muscleTargets: [MuscleTarget.lowerBack, MuscleTarget.glutes],
+    muscleTargets: [MuscleTarget.traps, MuscleTarget.glutes],
     jointTargets: [JointTarget.spine, JointTarget.hip],
   ),
   Exercise(
@@ -194,56 +138,74 @@ final List<Exercise> strengthExercises = [
     instructions:
         "1. Lean against a wall with your back flat against it.\n2. Slide down until your thighs are parallel to the ground.\n3. Hold this position for the desired amount of time.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.lowerBody],
     muscleTargets: [MuscleTarget.quadriceps, MuscleTarget.hamstrings],
     jointTargets: [JointTarget.knee, JointTarget.hip],
   ),
   Exercise(
-    name: 'Pistol Squats',
-    description: 'Advanced unilateral squat for leg strength and balance',
+    name: 'Calf Raises',
+    description: 'Lower leg exercise targeting the calf muscles',
     instructions:
-        "1. Stand on one leg with the other leg extended in front of you.\n2. Lower your body as if sitting back into a chair.\n3. Keep your chest up and knee over your toes.\n4. Push through your heel to return to standing.\n5. Repeat for desired reps, then switch legs.",
+        "1. Stand with feet hip-width apart.\n2. Raise your heels off the ground, standing on your toes.\n3. Lower your heels back to the ground.\n4. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.lowerBody],
-    muscleTargets: [
-      MuscleTarget.quadriceps,
-      MuscleTarget.hamstrings,
-      MuscleTarget.glutes,
-    ],
-    jointTargets: [JointTarget.knee, JointTarget.hip],
+    muscleTargets: [MuscleTarget.calves],
+    jointTargets: [JointTarget.ankle],
   ),
   Exercise(
-    name: 'Plyometric Push-ups',
-    description: 'Explosive push-up variation for power and strength',
+    name: 'Tricep Dips',
+    description: 'Upper body exercise focusing on triceps',
     instructions:
-        "1. Perform a push-up, then explosively push off the ground.\n2. Clap your hands together before landing back in the starting position.\n3. Repeat for desired reps.",
+        "1. Sit on a bench or chair with hands gripping the edge.\n2. Slide your buttocks off the bench, supporting your weight with your arms.\n3. Lower your body by bending your elbows.\n4. Push back up to the starting position.\n5. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.upperBody],
-    muscleTargets: [
-      MuscleTarget.chest,
-      MuscleTarget.shoulders,
-      MuscleTarget.triceps,
-    ],
-    jointTargets: [JointTarget.shoulder, JointTarget.elbow],
+    muscleTargets: [MuscleTarget.triceps],
+    jointTargets: [JointTarget.elbow],
   ),
   Exercise(
-    name: 'Handstand Push-ups',
-    description: 'Advanced shoulder and upper body exercise',
+    name: 'Lateral Raises',
+    description: 'Shoulder isolation exercise',
     instructions:
-        "1. Kick up into a handstand position against a wall.\n2. Lower your body by bending your elbows.\n3. Push back up to the starting position.\n4. Repeat for desired reps.",
+        "1. Stand with feet shoulder-width apart, holding light weights at your sides.\n2. Raise your arms out to the sides until they're parallel with the ground.\n3. Lower the weights back to your sides.\n4. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.upperBody],
-    muscleTargets: [MuscleTarget.shoulders, MuscleTarget.triceps],
-    jointTargets: [JointTarget.shoulder, JointTarget.elbow],
+    muscleTargets: [MuscleTarget.shoulders],
+    jointTargets: [JointTarget.shoulder],
   ),
   Exercise(
-    name: 'L-Sit',
-    description: 'Static hold exercise for core and hip flexor strength',
+    name: 'Bicycle Crunches',
+    description: 'Dynamic core exercise targeting abs and obliques',
     instructions:
-        "1. Sit on the ground with legs extended in front of you.\n2. Place your hands on the ground next to your hips.\n3. Lift your body off the ground, keeping legs straight.\n4. Hold this position for the desired amount of time.",
+        "1. Lie on your back with hands behind your head.\n2. Lift your shoulders off the ground and bring one knee towards your chest.\n3. Twist to bring the opposite elbow towards the knee.\n4. Alternate sides in a pedaling motion.\n5. Repeat for desired reps.",
     category: ExerciseCategory.strength,
-    focusAreas: [FocusArea.core],
-    muscleTargets: [MuscleTarget.core, MuscleTarget.hips],
+    muscleTargets: [MuscleTarget.abdominals, MuscleTarget.obliques],
+    jointTargets: [JointTarget.spine, JointTarget.hip],
+  ),
+  Exercise(
+    name: 'Leg Raises',
+    description: 'Core exercise focusing on lower abs and hip flexors',
+    instructions:
+        "1. Lie on your back with legs straight and hands by your sides.\n2. Keeping legs straight, lift them up towards the ceiling.\n3. Slowly lower your legs back down without touching the ground.\n4. Repeat for desired reps.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [MuscleTarget.abdominals, MuscleTarget.hipFlexors],
     jointTargets: [JointTarget.hip],
+  ),
+  Exercise(
+    name: 'Front and Side Arm Raises',
+    description: 'Shoulder exercise targeting deltoids',
+    instructions:
+        "1. Stand with feet shoulder-width apart, holding light weights.\n2. Raise arms straight in front of you to shoulder height.\n3. Lower arms, then raise them out to the sides to shoulder height.\n4. Lower arms back to starting position.\n5. Repeat for desired reps.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [MuscleTarget.shoulders],
+    jointTargets: [JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Plank to Downward Dog',
+    description: 'Dynamic core and upper body exercise',
+    instructions:
+        "1. Start in a plank position.\n2. Push your hips up and back, forming an inverted V shape with your body.\n3. Hold for a moment, then return to plank position.\n4. Repeat for desired reps.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [
+      MuscleTarget.abdominals,
+      MuscleTarget.shoulders,
+      MuscleTarget.triceps
+    ],
+    jointTargets: [JointTarget.shoulder, JointTarget.spine],
   ),
 ];

--- a/random_workout/lib/data/strength_exercises.dart
+++ b/random_workout/lib/data/strength_exercises.dart
@@ -208,4 +208,85 @@ final List<Exercise> strengthExercises = [
     ],
     jointTargets: [JointTarget.shoulder, JointTarget.spine],
   ),
+  Exercise(
+    name: 'Bicep Curls',
+    description: 'Isolation exercise for biceps',
+    instructions:
+        "1. Stand with feet shoulder-width apart, holding dumbbells at your sides.\n2. Keeping your upper arms stationary, curl the weights up to your shoulders.\n3. Slowly lower the weights back to the starting position.\n4. Repeat for desired reps.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [MuscleTarget.biceps, MuscleTarget.forearms],
+    jointTargets: [JointTarget.elbow],
+  ),
+  Exercise(
+    name: 'Standing Calf Raises',
+    description: 'Isolation exercise for calf muscles',
+    instructions:
+        "1. Stand on the edge of a step or platform, with your heels hanging off.\n2. Rise up onto your toes, lifting your heels as high as possible.\n3. Lower your heels below the level of the step, feeling a stretch in your calves.\n4. Repeat for desired reps.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [MuscleTarget.calves],
+    jointTargets: [JointTarget.ankle],
+  ),
+  Exercise(
+    name: 'Dumbbell Shrugs',
+    description: 'Upper body exercise focusing on the trapezius muscles',
+    instructions:
+        "1. Stand with feet shoulder-width apart, holding dumbbells at your sides.\n2. Lift your shoulders up towards your ears.\n3. Hold briefly, then lower your shoulders back down.\n4. Repeat for desired reps.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [MuscleTarget.traps],
+    jointTargets: [JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Standing Hip Abductions',
+    description: 'Lower body exercise targeting the hip abductor muscles',
+    instructions:
+        "1. Stand next to a wall or chair for support.\n2. Lift your outside leg out to the side, keeping it straight.\n3. Lower the leg back to the starting position.\n4. Repeat for desired reps, then switch sides.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [MuscleTarget.abductors],
+    jointTargets: [JointTarget.hip],
+  ),
+  Exercise(
+    name: 'Sumo Squats',
+    description: 'Lower body exercise targeting inner thighs and glutes',
+    instructions:
+        "1. Stand with feet wider than shoulder-width, toes pointed out.\n2. Lower your body as if sitting back into a chair.\n3. Keep your chest up and knees in line with your toes.\n4. Push through your heels to return to standing.\n5. Repeat for desired reps.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [
+      MuscleTarget.adductors,
+      MuscleTarget.quadriceps,
+      MuscleTarget.glutes
+    ],
+    jointTargets: [JointTarget.knee, JointTarget.hip],
+  ),
+  Exercise(
+    name: "Farmer's Walks",
+    description:
+        'Full body exercise with emphasis on forearms and grip strength',
+    instructions:
+        "1. Hold a heavy dumbbell or kettlebell in each hand.\n2. Walk forward with short, quick steps.\n3. Keep your shoulders back and core engaged.\n4. Continue for the desired distance or time.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [
+      MuscleTarget.forearms,
+      MuscleTarget.traps,
+      MuscleTarget.abdominals
+    ],
+    jointTargets: [JointTarget.shoulder, JointTarget.elbow, JointTarget.spine],
+  ),
+  Exercise(
+    name: 'Lying Leg Raises',
+    description: 'Core exercise targeting lower abs and hip flexors',
+    instructions:
+        "1. Lie on your back with legs straight and hands by your sides.\n2. Keeping your legs straight, lift them up towards the ceiling.\n3. Slowly lower your legs back down without touching the ground.\n4. Repeat for desired reps.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [MuscleTarget.abdominals, MuscleTarget.hipFlexors],
+    jointTargets: [JointTarget.hip],
+  ),
+  Exercise(
+    name: 'Seated Leg Adductions',
+    description: 'Lower body exercise targeting inner thigh muscles',
+    instructions:
+        "1. Sit on a chair with feet flat on the ground.\n2. Place a small ball or cushion between your knees.\n3. Squeeze your knees together, engaging your inner thighs.\n4. Hold for a few seconds, then release.\n5. Repeat for desired reps.",
+    category: ExerciseCategory.strength,
+    muscleTargets: [MuscleTarget.adductors],
+    jointTargets: [JointTarget.hip, JointTarget.knee],
+  ),
 ];

--- a/random_workout/lib/data/stretching_exercises.dart
+++ b/random_workout/lib/data/stretching_exercises.dart
@@ -7,17 +7,15 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Stand tall and step one foot forward.\n2. Keeping both legs straight, bend at the hips and lower your upper body towards your front leg.\n3. Reach for your toes or ankles.\n4. Hold for 20-30 seconds, then switch legs.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.legs],
     muscleTargets: [MuscleTarget.hamstrings],
     jointTargets: [JointTarget.knee, JointTarget.hip],
   ),
   Exercise(
     name: 'Butterfly Stretch',
-    description: 'Stretches the inner thighs and groin',
+    description: 'Stretches the inner thighs',
     instructions:
         "1. Sit on the floor with the soles of your feet together.\n2. Allow your knees to fall out to the sides.\n3. Gently press down on your knees with your elbows.\n4. Hold for 20-30 seconds.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.thighs],
     muscleTargets: [MuscleTarget.adductors],
     jointTargets: [JointTarget.hip],
   ),
@@ -27,9 +25,8 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Raise one arm overhead and bend it at the elbow.\n2. Use your other hand to gently pull the elbow behind your head.\n3. Hold for 20-30 seconds, then switch arms.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.arms],
     muscleTargets: [MuscleTarget.triceps],
-    jointTargets: [JointTarget.elbow],
+    jointTargets: [JointTarget.elbow, JointTarget.shoulder],
   ),
   Exercise(
     name: 'Seated Forward Bend',
@@ -37,9 +34,8 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Sit on the floor with legs extended in front of you.\n2. Reach forward with your hands towards your toes.\n3. Keep your back straight and bend from the hips.\n4. Hold for 20-30 seconds.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.legs],
     muscleTargets: [MuscleTarget.hamstrings],
-    jointTargets: [JointTarget.knee, JointTarget.hip],
+    jointTargets: [JointTarget.hip, JointTarget.spine],
   ),
   Exercise(
     name: 'Chest and Shoulder Stretch',
@@ -47,17 +43,15 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Stand in a doorway with your arms on the doorframe at shoulder height.\n2. Lean forward through the doorway until you feel a stretch.\n3. Hold for 20-30 seconds.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.upperBody],
     muscleTargets: [MuscleTarget.chest, MuscleTarget.shoulders],
     jointTargets: [JointTarget.shoulder],
   ),
   Exercise(
-    name: 'Quadriceps Stretch',
+    name: 'Standing Quad Stretch',
     description: 'Stretches the front of the thighs',
     instructions:
         "1. Stand on one leg, bend the other leg and grab your foot behind you.\n2. Pull your heel towards your buttocks.\n3. Hold for 20-30 seconds, then switch legs.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.thighs],
     muscleTargets: [MuscleTarget.quadriceps],
     jointTargets: [JointTarget.knee, JointTarget.hip],
   ),
@@ -67,7 +61,6 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Stand facing a wall with one foot behind you.\n2. Keep your back leg straight and press your heel into the ground.\n3. Lean forward until you feel a stretch in your calf.\n4. Hold for 20-30 seconds, then switch legs.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.calves],
     muscleTargets: [MuscleTarget.calves],
     jointTargets: [JointTarget.ankle],
   ),
@@ -77,7 +70,6 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Kneel on one knee with the other foot in front of you.\n2. Push your hips forward while keeping your back straight.\n3. Hold for 20-30 seconds, then switch legs.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.hips],
     muscleTargets: [MuscleTarget.hipFlexors],
     jointTargets: [JointTarget.hip],
   ),
@@ -87,8 +79,7 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Lie on your back with knees bent.\n2. Cross one ankle over the opposite knee.\n3. Pull the uncrossed leg towards your chest.\n4. Hold for 20-30 seconds, then switch legs.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.glutes],
-    muscleTargets: [MuscleTarget.piriformis],
+    muscleTargets: [MuscleTarget.glutes],
     jointTargets: [JointTarget.hip],
   ),
   Exercise(
@@ -97,29 +88,17 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Lie on your back with knees bent.\n2. Keep your shoulders flat on the ground and let your knees fall to one side.\n3. Turn your head in the opposite direction.\n4. Hold for 20-30 seconds, then switch sides.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.lowerBack],
-    muscleTargets: [MuscleTarget.lowerBack, MuscleTarget.obliques],
+    muscleTargets: [MuscleTarget.obliques],
     jointTargets: [JointTarget.spine],
   ),
   Exercise(
     name: "Child's Pose",
-    description: 'Stretches the back, hips, and arms',
+    description: 'Stretches the back, hips, and shoulders',
     instructions:
         "1. Kneel on the floor with toes together and knees apart.\n2. Sit back on your heels and stretch your arms forward.\n3. Rest your forehead on the ground.\n4. Hold for 30-60 seconds.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.lowerBack, FocusArea.hips, FocusArea.arms],
-    muscleTargets: [MuscleTarget.lowerBack, MuscleTarget.hipFlexors],
-    jointTargets: [JointTarget.knee, JointTarget.hip],
-  ),
-  Exercise(
-    name: 'Standing Quad Stretch',
-    description: 'Stretches the front of the thighs while standing',
-    instructions:
-        "1. Stand on one leg, bend the other leg and grab your foot behind you.\n2. Pull your heel towards your buttocks.\n3. Hold for 20-30 seconds, then switch legs.",
-    category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.thighs],
-    muscleTargets: [MuscleTarget.quadriceps],
-    jointTargets: [JointTarget.knee, JointTarget.hip],
+    muscleTargets: [MuscleTarget.hipFlexors, MuscleTarget.shoulders],
+    jointTargets: [JointTarget.hip, JointTarget.spine, JointTarget.shoulder],
   ),
   Exercise(
     name: 'Figure Four Stretch',
@@ -127,8 +106,7 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Lie on your back with knees bent.\n2. Cross one ankle over the opposite knee.\n3. Lift the uncrossed leg off the ground and pull it towards your chest.\n4. Hold for 20-30 seconds, then switch legs.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.glutes, FocusArea.hips],
-    muscleTargets: [MuscleTarget.glutes],
+    muscleTargets: [MuscleTarget.glutes, MuscleTarget.abductors],
     jointTargets: [JointTarget.hip],
   ),
   Exercise(
@@ -137,7 +115,6 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Lie face down with hands under your shoulders.\n2. Push your chest up while keeping your hips on the ground.\n3. Hold for 15-30 seconds.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.core],
     muscleTargets: [MuscleTarget.abdominals, MuscleTarget.chest],
     jointTargets: [JointTarget.spine],
   ),
@@ -147,8 +124,7 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Sit with legs extended.\n2. Bend one knee and place the foot outside of the opposite thigh.\n3. Twist your torso towards the bent knee.\n4. Hold for 20-30 seconds, then switch sides.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.lowerBack],
-    muscleTargets: [MuscleTarget.lowerBack],
+    muscleTargets: [MuscleTarget.obliques],
     jointTargets: [JointTarget.spine],
   ),
   Exercise(
@@ -157,9 +133,8 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Gently tilt your head to one side, bringing your ear towards your shoulder.\n2. Hold for 15-20 seconds, then switch sides.\n3. Repeat with chin tucked towards chest.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.neck],
-    muscleTargets: [MuscleTarget.neck],
-    jointTargets: [JointTarget.cervicalSpine],
+    muscleTargets: [MuscleTarget.traps],
+    jointTargets: [JointTarget.neck],
   ),
   Exercise(
     name: 'Wrist and Forearm Stretch',
@@ -167,18 +142,16 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Extend one arm in front of you with the palm facing up.\n2. Use your other hand to gently pull the fingers back towards your body.\n3. Hold for 15-20 seconds, then switch hands.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.forearms],
     muscleTargets: [MuscleTarget.forearms],
     jointTargets: [JointTarget.wrist],
   ),
   Exercise(
     name: 'Standing Side Bend',
-    description: 'Stretches the obliques and intercostal muscles',
+    description: 'Stretches the obliques and lats',
     instructions:
         "1. Stand with feet hip-width apart.\n2. Raise one arm overhead and lean to the opposite side.\n3. Feel the stretch along your side.\n4. Hold for 15-20 seconds, then switch sides.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.core],
-    muscleTargets: [MuscleTarget.obliques],
+    muscleTargets: [MuscleTarget.obliques, MuscleTarget.lats],
     jointTargets: [JointTarget.spine],
   ),
   Exercise(
@@ -187,7 +160,6 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Lie on your back with knees bent.\n2. Cross one ankle over the opposite knee.\n3. Grasp behind the uncrossed thigh and pull it towards your chest.\n4. Hold for 20-30 seconds, then switch legs.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.glutes],
     muscleTargets: [MuscleTarget.glutes],
     jointTargets: [JointTarget.hip],
   ),
@@ -198,8 +170,101 @@ final List<Exercise> stretchingExercises = [
     instructions:
         "1. Start on hands and knees.\n2. Lift your hips up and back, straightening your arms and legs.\n3. Press your heels towards the ground.\n4. Hold for 30-60 seconds, pedaling your feet if desired.",
     category: ExerciseCategory.stretching,
-    focusAreas: [FocusArea.arms, FocusArea.legs],
-    muscleTargets: [MuscleTarget.hamstrings, MuscleTarget.calves],
-    jointTargets: [JointTarget.ankle, JointTarget.shoulder],
+    muscleTargets: [
+      MuscleTarget.hamstrings,
+      MuscleTarget.calves,
+      MuscleTarget.shoulders
+    ],
+    jointTargets: [JointTarget.ankle, JointTarget.shoulder, JointTarget.spine],
+  ),
+  Exercise(
+    name: 'Standing Biceps Stretch',
+    description: 'Stretches the biceps and forearms',
+    instructions:
+        "1. Stand facing a wall, arm's length away.\n2. Place your palm on the wall at shoulder height, fingers pointing down.\n3. Slowly turn your body away from the wall until you feel a stretch.\n4. Hold for 20-30 seconds, then switch arms.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.biceps, MuscleTarget.forearms],
+    jointTargets: [JointTarget.elbow, JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Sphinx Pose',
+    description: 'Stretches the abdominals and lower back',
+    instructions:
+        "1. Lie face down with elbows under shoulders, forearms on the ground.\n2. Lift your upper body, keeping lower body relaxed on the floor.\n3. Hold for 15-30 seconds, breathing deeply.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.abdominals],
+    jointTargets: [JointTarget.spine],
+  ),
+  Exercise(
+    name: 'Standing Lat Stretch',
+    description: 'Stretches the latissimus dorsi muscles',
+    instructions:
+        "1. Stand with feet hip-width apart.\n2. Raise your right arm overhead, then bend it at the elbow.\n3. Grasp your right elbow with your left hand.\n4. Gently pull your right elbow behind your head while leaning to the left.\n5. Hold for 20-30 seconds, then switch sides.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.lats],
+    jointTargets: [JointTarget.shoulder, JointTarget.spine],
+  ),
+  Exercise(
+    name: 'Lying Quad Stretch',
+    description: 'Stretches the quadriceps while lying down',
+    instructions:
+        "1. Lie on your right side.\n2. Bend your left knee and grasp your left foot with your left hand.\n3. Gently pull your heel towards your buttocks.\n4. Hold for 20-30 seconds, then switch sides.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.quadriceps],
+    jointTargets: [JointTarget.knee, JointTarget.hip],
+  ),
+  Exercise(
+    name: 'Standing Hip Abductor Stretch',
+    description: 'Stretches the hip abductor muscles',
+    instructions:
+        "1. Stand behind a chair, holding it for balance.\n2. Cross your right leg behind your left leg.\n3. Lean your hips to the right until you feel a stretch on the outside of your left hip.\n4. Hold for 20-30 seconds, then switch sides.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.abductors],
+    jointTargets: [JointTarget.hip],
+  ),
+  Exercise(
+    name: 'Seated Adductor Stretch',
+    description: 'Stretches the inner thigh muscles',
+    instructions:
+        "1. Sit on the floor with your back straight.\n2. Bring the soles of your feet together, allowing your knees to fall out to the sides.\n3. Gently press down on your knees with your elbows.\n4. Lean forward slightly to increase the stretch.\n5. Hold for 20-30 seconds.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.adductors],
+    jointTargets: [JointTarget.hip],
+  ),
+  Exercise(
+    name: 'Wall Chest Stretch',
+    description: 'Stretches the chest muscles',
+    instructions:
+        "1. Stand facing a wall, arm's length away.\n2. Place your right palm on the wall at shoulder height.\n3. Slowly turn your body to the left until you feel a stretch in your chest.\n4. Hold for 20-30 seconds, then switch sides.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.chest],
+    jointTargets: [JointTarget.shoulder],
+  ),
+  Exercise(
+    name: 'Kneeling Hip Flexor Stretch',
+    description: 'Stretches the hip flexors and quadriceps',
+    instructions:
+        "1. Kneel on your right knee, left foot planted in front.\n2. Push your hips forward while keeping your back straight.\n3. Raise your right arm overhead and lean slightly to the left.\n4. Hold for 20-30 seconds, then switch sides.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.hipFlexors, MuscleTarget.quadriceps],
+    jointTargets: [JointTarget.hip, JointTarget.knee],
+  ),
+  Exercise(
+    name: 'Seated Forward Bend with Twist',
+    description: 'Stretches the hamstrings, lower back, and obliques',
+    instructions:
+        "1. Sit with legs extended in front of you.\n2. Bend your right knee, placing your right foot outside your left thigh.\n3. Twist your torso to the right, placing your left elbow outside your right knee.\n4. Hold for 20-30 seconds, then switch sides.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.hamstrings, MuscleTarget.obliques],
+    jointTargets: [JointTarget.hip, JointTarget.spine],
+  ),
+  Exercise(
+    name: 'Neck and Trap Release',
+    description: 'Stretches the neck and upper trapezius muscles',
+    instructions:
+        "1. Sit or stand with a straight back.\n2. Tilt your head to the right, bringing your ear towards your shoulder.\n3. Gently place your right hand on the left side of your head.\n4. Apply light pressure to increase the stretch.\n5. Hold for 15-20 seconds, then switch sides.",
+    category: ExerciseCategory.stretching,
+    muscleTargets: [MuscleTarget.traps],
+    jointTargets: [JointTarget.neck],
   ),
 ];

--- a/random_workout/lib/models/exercise.dart
+++ b/random_workout/lib/models/exercise.dart
@@ -20,35 +20,21 @@ enum ExerciseCategory {
 
 enum MuscleTarget with LabeledEnum {
   abdominals('Abdominals'),
-  abductors('Abductors'),
-  adductors('Adductors'),
-  back('Back'),
   biceps('Biceps'),
   calves('Calves'),
   chest('Chest'),
-  core('Core'),
-  erectorSpinae('Erector Spinae'),
   forearms('Forearms'),
   glutes('Glutes'),
   hamstrings('Hamstrings'),
-  hips('Hips'),
-  hipFlexors('Hip Flexors'),
-  lats('Latissimus Dorsi'),
-  lowerBack('Lower Back'),
-  lowerBody('Lower Body'),
-  neck('Neck'),
-  neckMuscles('Neck Muscles'),
+  lats('Lats'),
   obliques('Obliques'),
-  piriformis('Piriformis'),
-  quadriceps('Quadriceps'),
-  rhomboids('Rhomboids'),
-  rotatorCuff('Rotator Cuff'),
-  serratus('Serratus'),
+  quadriceps('Quads'),
   shoulders('Shoulders'),
-  tibialis('Tibialis'),
-  traps('Trapezius'),
+  traps('Traps'),
   triceps('Triceps'),
-  upperBack('Upper Back');
+  hipFlexors('Hip Flexors'),
+  abductors('Abductors'),
+  adductors('Adductors');
 
   @override
   final String label;
@@ -57,48 +43,17 @@ enum MuscleTarget with LabeledEnum {
 
 enum JointTarget with LabeledEnum {
   ankle('Ankle'),
-  cervicalSpine('Cervical Spine'),
   elbow('Elbow'),
   hip('Hip'),
   knee('Knee'),
-  lumbarSpine('Lumbar Spine'),
+  neck('Neck'),
   shoulder('Shoulder'),
   spine('Spine'),
-  thoracicSpine('Thoracic Spine'),
   wrist('Wrist');
 
   @override
   final String label;
   const JointTarget(this.label);
-}
-
-enum FocusArea with LabeledEnum {
-  ankles('Ankles'),
-  arms('Arms'),
-  calves('Calves'),
-  chest('Chest'),
-  core('Core'),
-  feet('Feet'),
-  forearms('Forearms'),
-  fullBody('Full Body'),
-  glutes('Glutes'),
-  hands('Hands'),
-  head('Head'),
-  hips('Hips'),
-  knees('Knees'),
-  legs('Legs'),
-  lowerBack('Lower Back'),
-  lowerBody('Lower Body'),
-  neck('Neck'),
-  shoulders('Shoulders'),
-  thighs('Thighs'),
-  upperBack('Upper Back'),
-  upperBody('Upper Body'),
-  wrists('Wrists');
-
-  @override
-  final String label;
-  const FocusArea(this.label);
 }
 
 class Exercise {
@@ -108,7 +63,6 @@ class Exercise {
   final ExerciseCategory category;
   final List<MuscleTarget>? muscleTargets;
   final List<JointTarget>? jointTargets;
-  final List<FocusArea>? focusAreas;
 
   Exercise({
     required this.name,
@@ -117,7 +71,6 @@ class Exercise {
     required this.category,
     required this.muscleTargets,
     required this.jointTargets,
-    required this.focusAreas,
   });
 }
 
@@ -146,9 +99,7 @@ extension ExerciseScore on Exercise {
     if (jointTargets != null) {
       score += jointTargets!.length;
     }
-    if (focusAreas != null) {
-      score += focusAreas!.length;
-    }
+
     return score;
   }
 }

--- a/random_workout/lib/pages/target_selection_page.dart
+++ b/random_workout/lib/pages/target_selection_page.dart
@@ -9,7 +9,7 @@ class TargetSelectionPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 3,
+      length: 2,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Select Workout Targets'),
@@ -17,7 +17,6 @@ class TargetSelectionPage extends StatelessWidget {
             tabs: [
               Tab(text: 'Muscles'),
               Tab(text: 'Joints'),
-              Tab(text: 'Focus Areas'),
             ],
           ),
         ),

--- a/random_workout/lib/pages/target_selection_page.dart
+++ b/random_workout/lib/pages/target_selection_page.dart
@@ -25,7 +25,6 @@ class TargetSelectionPage extends StatelessWidget {
           children: [
             _buildTargetList<MuscleTarget>(context),
             _buildTargetList<JointTarget>(context),
-            _buildTargetList<FocusArea>(context),
           ],
         ),
         floatingActionButton: FloatingActionButton(
@@ -38,11 +37,8 @@ class TargetSelectionPage extends StatelessWidget {
 
   Widget _buildTargetList<T extends Enum>(BuildContext context) {
     final appState = Provider.of<AppState>(context);
-    final targets = T == MuscleTarget
-        ? MuscleTarget.values
-        : T == JointTarget
-            ? JointTarget.values
-            : FocusArea.values;
+    final targets =
+        T == MuscleTarget ? MuscleTarget.values : JointTarget.values;
 
     return ListView.builder(
       itemCount: targets.length,
@@ -64,9 +60,8 @@ class TargetSelectionPage extends StatelessWidget {
       return target.label;
     } else if (target is JointTarget) {
       return target.label;
-    } else if (target is FocusArea) {
-      return target.label;
     }
+
     return target.toString().split('.').last;
   }
 }

--- a/random_workout/lib/providers/app_state.dart
+++ b/random_workout/lib/providers/app_state.dart
@@ -93,9 +93,6 @@ class AppState extends ChangeNotifier {
     exercise.jointTargets?.forEach((joint) {
       _targetCounts[joint] = (_targetCounts[joint] ?? 0) + 1;
     });
-    exercise.focusAreas?.forEach((focus) {
-      _targetCounts[focus] = (_targetCounts[focus] ?? 0) + 1;
-    });
   }
 
   void _recalculateTargetCounts() {
@@ -139,12 +136,6 @@ class AppState extends ChangeNotifier {
               .length *
           2;
     }
-    if (exercise.focusAreas != null) {
-      score += exercise.focusAreas!
-              .where((focus) => _selectedTargets.contains(focus))
-              .length *
-          2;
-    }
 
     // Add a base score to ensure exercises without selected targets still have a chance
     score += exercise.score;
@@ -185,10 +176,6 @@ class AppState extends ChangeNotifier {
       exercise.jointTargets?.forEach((joint) {
         uniqueTargets.add(joint);
       });
-
-      exercise.focusAreas?.forEach((focus) {
-        uniqueTargets.add(focus);
-      });
     }
 
     return uniqueTargets.length;
@@ -212,8 +199,6 @@ class AppState extends ChangeNotifier {
         groupedCounts['Muscles']!.add(entry);
       } else if (entry.key is JointTarget) {
         groupedCounts['Joints']!.add(entry);
-      } else if (entry.key is FocusArea) {
-        groupedCounts['Focus Areas']!.add(entry);
       }
     }
 

--- a/random_workout/lib/widgets/exercise/create_exercise_dialog.dart
+++ b/random_workout/lib/widgets/exercise/create_exercise_dialog.dart
@@ -21,7 +21,6 @@ class _CreateExerciseDialogState extends State<CreateExerciseDialog> {
   final instructionsController = TextEditingController();
   List<MuscleTarget> selectedMuscleTargets = [];
   List<JointTarget> selectedJointTargets = [];
-  List<FocusArea> selectedFocusAreas = [];
 
   @override
   Widget build(BuildContext context) {
@@ -53,11 +52,6 @@ class _CreateExerciseDialogState extends State<CreateExerciseDialog> {
               'Joint Targets',
               JointTarget.values,
               selectedJointTargets,
-            ),
-            _buildTargetSection<FocusArea>(
-              'Special Targets',
-              FocusArea.values,
-              selectedFocusAreas,
             ),
           ],
         ),
@@ -109,8 +103,6 @@ class _CreateExerciseDialogState extends State<CreateExerciseDialog> {
       return target.label;
     } else if (target is JointTarget) {
       return target.label;
-    } else if (target is FocusArea) {
-      return target.label;
     }
     return target.toString();
   }
@@ -129,7 +121,6 @@ class _CreateExerciseDialogState extends State<CreateExerciseDialog> {
             selectedMuscleTargets.isNotEmpty ? selectedMuscleTargets : null,
         jointTargets:
             selectedJointTargets.isNotEmpty ? selectedJointTargets : null,
-        focusAreas: selectedFocusAreas.isNotEmpty ? selectedFocusAreas : null,
       );
       widget.onExerciseCreated(newExercise);
       Navigator.of(context).pop();

--- a/random_workout/lib/widgets/exercise/exercise_list_tile.dart
+++ b/random_workout/lib/widgets/exercise/exercise_list_tile.dart
@@ -38,9 +38,6 @@ class ExerciseListTile extends StatelessWidget {
                 exercise.jointTargets!.isNotEmpty)
               Text(
                   'Joints: ${exercise.jointTargets!.map((t) => t.label).join(", ")}'),
-            if (exercise.focusAreas != null && exercise.focusAreas!.isNotEmpty)
-              Text(
-                  'Focus: ${exercise.focusAreas!.map((t) => t.label).join(", ")}'),
           ],
         ),
         leading: IconButton(

--- a/random_workout/lib/widgets/workout/workout_diversity_dialog.dart
+++ b/random_workout/lib/widgets/workout/workout_diversity_dialog.dart
@@ -76,8 +76,6 @@ class WorkoutDiversityDialog extends StatelessWidget {
       return target.label;
     } else if (target is JointTarget) {
       return target.label;
-    } else if (target is FocusArea) {
-      return target.label;
     }
     return target.toString(); // Fallback, shouldn't be needed
   }

--- a/random_workout/test/models/exercise_test.dart
+++ b/random_workout/test/models/exercise_test.dart
@@ -11,7 +11,6 @@ void main() {
         category: ExerciseCategory.strength,
         muscleTargets: [MuscleTarget.chest, MuscleTarget.triceps],
         jointTargets: [JointTarget.elbow],
-        focusAreas: [FocusArea.upperBody],
       );
 
       expect(exercise.name, 'Push-ups');
@@ -20,13 +19,11 @@ void main() {
       expect(
           exercise.muscleTargets, [MuscleTarget.chest, MuscleTarget.triceps]);
       expect(exercise.jointTargets, [JointTarget.elbow]);
-      expect(exercise.focusAreas, [FocusArea.upperBody]);
     });
 
     test('should return correct labels for targets', () {
       expect(MuscleTarget.chest.label, 'Chest');
       expect(JointTarget.knee.label, 'Knee');
-      expect(FocusArea.lowerBack.label, 'Lower Back');
     });
   });
 }

--- a/random_workout/test/unit/providers/app_state_test.dart
+++ b/random_workout/test/unit/providers/app_state_test.dart
@@ -19,7 +19,6 @@ void main() {
         instructions: 'Do a push-up',
         muscleTargets: [MuscleTarget.chest, MuscleTarget.triceps],
         jointTargets: [JointTarget.elbow],
-        focusAreas: [FocusArea.upperBody],
       ),
       Exercise(
         name: 'Squats',
@@ -28,7 +27,6 @@ void main() {
         category: ExerciseCategory.strength,
         muscleTargets: [MuscleTarget.quadriceps],
         jointTargets: [JointTarget.knee],
-        focusAreas: [FocusArea.lowerBody],
       ),
     ];
 
@@ -42,7 +40,6 @@ void main() {
       for (var exercise in workout) {
         uniqueTargets.addAll(exercise.muscleTargets ?? []);
         uniqueTargets.addAll(exercise.jointTargets ?? []);
-        uniqueTargets.addAll(exercise.focusAreas ?? []);
       }
       return uniqueTargets.length;
     });
@@ -60,7 +57,6 @@ void main() {
         category: ExerciseCategory.strength,
         muscleTargets: [MuscleTarget.chest, MuscleTarget.triceps],
         jointTargets: [JointTarget.elbow],
-        focusAreas: [FocusArea.upperBody],
       ),
       Exercise(
         name: 'Squats',
@@ -69,7 +65,6 @@ void main() {
         category: ExerciseCategory.strength,
         muscleTargets: [MuscleTarget.quadriceps],
         jointTargets: [JointTarget.knee],
-        focusAreas: [FocusArea.lowerBody],
       ),
     ];
 
@@ -86,10 +81,6 @@ void main() {
       'Joints': [
         const MapEntry(JointTarget.elbow, 1),
         const MapEntry(JointTarget.knee, 1),
-      ],
-      'Focus Areas': [
-        const MapEntry(FocusArea.upperBody, 1),
-        const MapEntry(FocusArea.lowerBody, 1),
       ],
     };
 

--- a/random_workout/test/widget/pages/workout_page_test.dart
+++ b/random_workout/test/widget/pages/workout_page_test.dart
@@ -76,7 +76,6 @@ void main() {
         category: ExerciseCategory.strength,
         muscleTargets: [MuscleTarget.chest, MuscleTarget.triceps],
         jointTargets: [JointTarget.elbow],
-        focusAreas: [FocusArea.upperBody],
       ),
       Exercise(
         name: 'Squats',
@@ -85,7 +84,6 @@ void main() {
         category: ExerciseCategory.strength,
         muscleTargets: [MuscleTarget.quadriceps],
         jointTargets: [JointTarget.knee],
-        focusAreas: [FocusArea.lowerBody],
       ),
     ];
 

--- a/random_workout/test/widget/widgets/exercise/exercise_list_tile_test.dart
+++ b/random_workout/test/widget/widgets/exercise/exercise_list_tile_test.dart
@@ -13,7 +13,6 @@ void main() {
       category: ExerciseCategory.strength,
       muscleTargets: [MuscleTarget.quadriceps, MuscleTarget.glutes],
       jointTargets: [JointTarget.knee],
-      focusAreas: [FocusArea.lowerBody],
     );
 
     await tester.pumpWidget(


### PR DESCRIPTION
This pull request simplifies and improves the exercises in the codebase. It removes the `focusAreas` property from the `Exercise` class and related code, as it is no longer needed. Additionally, it simplifies the `TargetSelectionPage` by removing the `FocusArea` target list. These changes make the codebase cleaner and more streamlined.